### PR TITLE
Updating LinkedInAuthorizationViewController for login fix

### DIFF
--- a/Demo/LinkedInIOSHelper/LinkedInHelper/LinkedInAuthorizationViewController.m
+++ b/Demo/LinkedInIOSHelper/LinkedInHelper/LinkedInAuthorizationViewController.m
@@ -166,6 +166,7 @@ NSString * const linkedinIosHelperDomain = @"com.linkedinioshelper";
     
     NSMutableDictionary *mdQueryStrings = [[NSMutableDictionary alloc] init];
     urlString = [[urlString componentsSeparatedByString:@"?"] objectAtIndex:1];
+    urlString = [[urlString componentsSeparatedByString:@"#"] objectAtIndex:0];
     for (NSString *qs in [urlString componentsSeparatedByString:@"&"]) {
         [mdQueryStrings setValue:[[[[qs componentsSeparatedByString:@"="] objectAtIndex:1]
                                    stringByReplacingOccurrencesOfString:@"+" withString:@" "]


### PR DESCRIPTION
 for issue #5:
ignoring the url after fragment identifier “#” to enusre that only
parameters are parsed which extracting the parameter values.
